### PR TITLE
changed sqs arn to be passed as a list

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ module "step_function" {
     }
 
     sqs = {
-      sqs = "arn:aws:sqs:..."  # sqs queue ARN is required because there is no default_resources key for such integration
+      sqs = ["arn:aws:sqs:..."]  # sqs queue ARN is required because there is no default_resources key for such integration
     }
 
     # Special case to deny all actions for the step function (this will override all IAM policies allowed for the function)


### PR DESCRIPTION
If the arn is not passed as a list, an invalid function argument is thrown:
Invalid value for "v" parameter: cannot convert string to list of any single type.